### PR TITLE
Remove cPy3.6 runner support, remove pypy3 runner support on macOS

### DIFF
--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: Linux CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: macOS CI
     steps:
       - name: Check out source repository

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: Windows CI
     steps:
       - name: Check out source repository


### PR DESCRIPTION
Drops nightly CI tests for cPy 3.6 Linux, macOS, and Windows runner environments.

There appears to be an issue with the @actions/python-setup installation of pypy3 on macOS. Will remove pypy3 nightly tests on macOS-latest for now.