### PR TITLE
Update flake8 remote git repository for master/main branch installations

### DIFF
--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: "tests/test-default.py" # have to restrict because there are other tests with flake8 fails
       - name: Run ${{ matrix.python-version }} platform tests (with args)
-        uses: py-actions/flake8@master
+        uses: py-actions/flake8@flake8-repo
         with:
           update-pip: "true"
           ignore: "F401"

--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -35,4 +35,4 @@ jobs:
           max-line-length: "100"
           args: "--quiet"
           path: "tests/test-args.py"
-          flake8-version: "master"
+          flake8-version: "main"

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: "tests/test-default.py" # have to restrict because there are other tests with flake8 fails
       - name: Run ${{ matrix.python-version }} platform tests (with args)
-        uses: py-actions/flake8@master
+        uses: py-actions/flake8@flake8-repo
         with:
           update-pip: "true"
           ignore: "F401"

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -35,4 +35,4 @@ jobs:
           max-line-length: "100"
           args: "--quiet"
           path: "tests/test-args.py"
-          flake8-version: "master"
+          flake8-version: "main"

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           path: "tests/test-default.py" # have to restrict because there are other tests with flake8 fails
       - name: Run ${{ matrix.python-version }} platform tests (with args)
-        uses: py-actions/flake8@master
+        uses: py-actions/flake8@flake8-repo
         with:
           update-pip: "true"
           ignore: "F401"

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -37,4 +37,4 @@ jobs:
           max-line-length: "100"
           args: "--quiet"
           path: "tests/test-args.py"
-          flake8-version: "master"
+          flake8-version: "main"

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Configure the Action with the following *optional* settings:
 
 ### `flake8-version`
 
-**Optional** flake8 version for testing. Options: ['latest', 'master', '[VERSION NUMBER]'].Default = `"latest"`.
+**Optional** flake8 version for testing. Options: ['latest', 'main', 'master', '[VERSION NUMBER]'].Default = `"latest"`.
 
 - 'latest' = current PyPI release version
-- 'master' = current [GitLab source repository master branch version](https://gitlab.com/pycqa/flake8)
+- 'main' = current [GitHub source repository main branch version](https://github.com/PyCQA/flake8)
 - '[VERSION NUMBER]' = the version number of the [flake8 PyPI package](https://pypi.org/project/flake8/) (e.g., `"3.7.9"`)
 
 ### `path`

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   flake8-version:
     description: "The flake8 version for tests (optional, default='latest')"
     required: false
-    default: "latest" # possible values ['latest', 'master', '[VERSION NUMBER]']
+    default: "latest" # possible values ['latest', 'master', 'main', '[VERSION NUMBER]']
 
 runs:
   using: "node16"

--- a/dist/index.js
+++ b/dist/index.js
@@ -3253,7 +3253,7 @@ async function run() {
     console.log(`[*] Installing flake8 package @ ${flake8Version}...`);
     if (flake8Version === "latest") {
       await exec.exec("python -m pip install --upgrade flake8");
-    } else if (flake8Version === "master") {
+    } else if (flake8Version === "master" || flake8Version === "main") {
       await exec.exec(
         "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );

--- a/dist/index.js
+++ b/dist/index.js
@@ -3255,7 +3255,7 @@ async function run() {
       await exec.exec("python -m pip install --upgrade flake8");
     } else if (flake8Version === "master") {
       await exec.exec(
-        "python -m pip install --upgrade git+https://gitlab.com/pycqa/flake8.git"
+        "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );
     } else {
       await exec.exec(

--- a/dist/index.js
+++ b/dist/index.js
@@ -3253,7 +3253,11 @@ async function run() {
     console.log(`[*] Installing flake8 package @ ${flake8Version}...`);
     if (flake8Version === "latest") {
       await exec.exec("python -m pip install --upgrade flake8");
-    } else if (flake8Version === "master" || flake8Version === "main") {
+    } else if (flake8Version === "main") {
+      await exec.exec(
+        "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
+      );
+    } else if (flake8Version === "master") {
       await exec.exec(
         "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ async function run() {
     console.log(`[*] Installing flake8 package @ ${flake8Version}...`);
     if (flake8Version === "latest") {
       await exec.exec("python -m pip install --upgrade flake8");
-    } else if (flake8Version === "master") {
+    } else if (flake8Version === "master" || flake8Version === "main") {
       await exec.exec(
         "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ async function run() {
       await exec.exec("python -m pip install --upgrade flake8");
     } else if (flake8Version === "master") {
       await exec.exec(
-        "python -m pip install --upgrade git+https://gitlab.com/pycqa/flake8.git"
+        "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );
     } else {
       await exec.exec(

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,11 @@ async function run() {
     console.log(`[*] Installing flake8 package @ ${flake8Version}...`);
     if (flake8Version === "latest") {
       await exec.exec("python -m pip install --upgrade flake8");
-    } else if (flake8Version === "master" || flake8Version === "main") {
+    } else if (flake8Version === "main") {
+      await exec.exec(
+        "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
+      );
+    } else if (flake8Version === "master") {
       await exec.exec(
         "python -m pip install --upgrade git+https://github.com/PyCQA/flake8.git"
       );


### PR DESCRIPTION
From gitlab to https://github.com/PyCQA/flake8.git

The default branch is `main` in the GitHub repository.  We will also add support for `flake8-version: "main"` (and maintain the previous support for the use of "master" in the flake8-version definition).  Both "master" and "main" will point to the GitHub repository default branch.
