### PR TITLE
Update version of GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Node 20 eslint run
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/linuxci.yml
+++ b/.github/workflows/linuxci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Linux CI
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python environment report

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -15,9 +15,9 @@ jobs:
     name: macOS CI
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python environment report

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Windows CI
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       # - name: Windows-specific Python environment workaround

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: flake8 Lint
@@ -48,9 +48,9 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: flake8 Lint


### PR DESCRIPTION
Updating the actions `actions/checkout` and `actions/setup-python` removes the warnings about deprecated Node.js versions. Furthermore, the examples should not mentioned these old actions anymore.